### PR TITLE
Fixed division by zero error

### DIFF
--- a/rank_bm25.py
+++ b/rank_bm25.py
@@ -95,7 +95,7 @@ class BM25Okapi(BM25):
             idf_sum += idf
             if idf < 0:
                 negative_idfs.append(word)
-        self.average_idf = idf_sum / len(self.idf)
+        self.average_idf = idf_sum / len(self.idf) if len(self.idf) > 0 else 0
 
         eps = self.epsilon * self.average_idf
         for word in negative_idfs:


### PR DESCRIPTION
I ran the module, and for some reason the length of idf was 0 which gave me the error, however we're setting the avg idf to 0 if the length of idf is 0  
We may also have to do this with the other bm25 modules 