### PR TITLE
Support non-repeatably iterable corpus for tokenizer=None

### DIFF
--- a/rank_bm25.py
+++ b/rank_bm25.py
@@ -14,7 +14,7 @@ Here we implement all the BM25 variations mentioned.
 
 class BM25:
     def __init__(self, corpus, tokenizer=None):
-        self.corpus_size = len(corpus)
+        self.corpus_size = 0
         self.avgdl = 0
         self.doc_freqs = []
         self.idf = {}
@@ -46,6 +46,8 @@ class BM25:
                     nd[word]+=1
                 except KeyError:
                     nd[word] = 1
+
+            self.corpus_size += 1
 
         self.avgdl = num_doc / self.corpus_size
         return nd


### PR DESCRIPTION
Currently, rank-bm25 requires that `corpus` is repeatedly iterable and sized (i.e. defines `__len__()`).

When the corpus is not pre-tokenized (i.e. `tokenizer` is not None), then this makes sense: `__init__()` will iterate across the corpus several times, so we may as well require that the corpus is a list or some other data type that is repeatedly iterable and sized. However, when the corpus is pre-tokenized (i.e. `tokenizer` is None), then we only iterate over the corpus once in `_initialize()`. Furthermore, we don't need to know its size beforehand, because we can just count the number of iterations.

This pull request makes it possible to use a non-repeatedly iterable non-sized corpus such as a generator when `tokenizer` is None. This is useful if you need to generate your corpus on the fly and don't know the number of your documents beforehand.