### PR TITLE
Remove extraneous `q_freq` factor from BM25L score

### DIFF
--- a/rank_bm25.py
+++ b/rank_bm25.py
@@ -153,7 +153,7 @@ class BM25L(BM25):
         for q in query:
             q_freq = np.array([(doc.get(q) or 0) for doc in self.doc_freqs])
             ctd = q_freq / (1 - self.b + self.b * doc_len / self.avgdl)
-            score += (self.idf.get(q) or 0) * q_freq * (self.k1 + 1) * (ctd + self.delta) / \
+            score += (self.idf.get(q) or 0) * (self.k1 + 1) * (ctd + self.delta) / \
                      (self.k1 + ctd + self.delta)
         return score
 
@@ -167,7 +167,7 @@ class BM25L(BM25):
         for q in query:
             q_freq = np.array([(self.doc_freqs[di].get(q) or 0) for di in doc_ids])
             ctd = q_freq / (1 - self.b + self.b * doc_len / self.avgdl)
-            score += (self.idf.get(q) or 0) * q_freq * (self.k1 + 1) * (ctd + self.delta) / \
+            score += (self.idf.get(q) or 0) * (self.k1 + 1) * (ctd + self.delta) / \
                      (self.k1 + ctd + self.delta)
         return score.tolist()
 


### PR DESCRIPTION
In [the paper][1], the tf<sub>td</sub> factor in the BM25L scoring formula is contained within c<sub>td</sub>:

![BM25 scoring formula](https://user-images.githubusercontent.com/603082/158365053-3f8fa6d6-0256-4417-864a-37e79a93455b.png)

However, in the rank-bm25 library, the tf<sub>td</sub> factor is used in addition to c<sub>td</sub>, leading to tf<sub>td</sub> · (k<sub>1</sub> + 1) · (c<sub>td</sub> + δ) in the numerator. This PR fixes that.

 [1]: http://www.cs.otago.ac.nz/homepages/andrew/papers/2014-2.pdf#page=2