### PR TITLE
Replace division in `math.log()` with subtraction

### DIFF
--- a/rank_bm25.py
+++ b/rank_bm25.py
@@ -182,7 +182,7 @@ class BM25Plus(BM25):
 
     def _calc_idf(self, nd):
         for word, freq in nd.items():
-            idf = math.log((self.corpus_size + 1) / freq)
+            idf = math.log(self.corpus_size + 1) - math.log(freq)
             self.idf[word] = idf
 
     def get_scores(self, query):


### PR DESCRIPTION
In the `_calc_idf()` method of `BM25Plus`, a division is used in `math.log()`, which is less stable than a subtraction of two logarithms. This PR replaces the division with subtraction,