### PR TITLE
Debug BM25Okapi

### DIFF
--- a/rank_bm25.py
+++ b/rank_bm25.py
@@ -100,7 +100,7 @@ class BM25Okapi(BM25):
                 negative_idfs.append(word)
         self.average_idf = idf_sum / len(self.idf)
 
-        eps = self.epsilon * self.average_idf
+        eps = max(self.epsilon * self.average_idf, 0.001)  # average_idf must be positive
         for word in negative_idfs:
             self.idf[word] = eps
 


### PR DESCRIPTION
In the "BM25Okapi" function "_calc_idfIf", if average_idf is negative, the eps will be negative, so the BM25 score also will be negative. So this commit will debug this error.